### PR TITLE
Black/Grey Accent Colour Theme

### DIFF
--- a/Customization/Account Name/Hide Account Name/resource/layout/steamrootdialog.layout
+++ b/Customization/Account Name/Hide Account Name/resource/layout/steamrootdialog.layout
@@ -176,18 +176,12 @@
 		new_label	
 		{			
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 		
 		new_label:hover
 		{
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 

--- a/Customization/Account Name/Show Account Name/resource/layout/steamrootdialog.layout
+++ b/Customization/Account Name/Show Account Name/resource/layout/steamrootdialog.layout
@@ -176,18 +176,12 @@
 		new_label	
 		{			
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 		
 		new_label:hover
 		{
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 

--- a/Customization/Sidebar Width/Collapsed Sidebar/resource/layout/steamrootdialog.layout
+++ b/Customization/Sidebar Width/Collapsed Sidebar/resource/layout/steamrootdialog.layout
@@ -176,18 +176,12 @@
 		new_label	
 		{			
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 		
 		new_label:hover
 		{
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 

--- a/Customization/Sidebar Width/Collapsed Sidebar/resource/layout/uistatuspanel.layout
+++ b/Customization/Sidebar Width/Collapsed Sidebar/resource/layout/uistatuspanel.layout
@@ -14,7 +14,7 @@
 		{
 			render
 			{
-				0="image( x0+15, y0+15, x1, y1, graphics/Threshold/downloads)"
+				0="image( x0+9, y0+8, x1, y1, graphics/Threshold/downloads)"
 			}
 		}
 		

--- a/Customization/Sidebar Width/Expanded Sidebar/resource/layout/steamrootdialog.layout
+++ b/Customization/Sidebar Width/Expanded Sidebar/resource/layout/steamrootdialog.layout
@@ -176,18 +176,12 @@
 		new_label	
 		{			
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 		
 		new_label:hover
 		{
 			bgcolor=none
-			render{
-				0="image(x0,y0,x1,y1,graphics/Threshold/tmp/beta)"
-			}
 			inset="0 0 0 0"
 		}
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A Windows 10 Style Steam Skin
 [Steam Community Group](http://steamcommunity.com/groups/thresholdskin)  
 [Wiki](http://github.com/Edgarware/Threshold-Skin/wiki)
 
-##Installation
+## Installation
 Copy the skin folder to C:\Program Files (x86)\Steam\skins
 
 In Steam go to Settings > Interface > and choose Threshold from the list of skins
 
 Restart Steam and enjoy!
 
-##TODO
+## TODO
 * OSX/Linux support
   * Works fine on Linux but Segoe UI renders too large. In the process of fixing font-sizes.
   * OSX support untested, likely in similar situation to Linux.


### PR DESCRIPTION
Would like a black/grey theme for accent colours since I don't really like anything really bright.

Also, another request: Option to choose the _exact_ position of notifications. I got briefly excited when I read you could choose your notification position until I saw you can only choose top/bottom left/right. I use 3 monitors, and it's always bugged me that I never notice notifications because they appear out of my normal field of view on the end of the right monitor, when I'm normally focused on my middle monitor. Would be cool to be able to offset the position so it shows up on the bottom right of my middle monitor!
