### PR TITLE
Frame.Focus.Text is now defined in specific color config

### DIFF
--- a/resource/styles/colors/cobalt.styles
+++ b/resource/styles/colors/cobalt.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="0 90 158 255"
 		Accent.Selected="25 106 167 255"
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="255 185 0 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/cyan.styles
+++ b/resource/styles/colors/cyan.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="0 107 131 255"
 		Accent.Selected="25 121 143 255"
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="178 82 0 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/gray.styles
+++ b/resource/styles/colors/gray.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="122 117 116 255"
 		Accent.Selected="135 130 129 255"
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="255 255 255 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/green.styles
+++ b/resource/styles/colors/green.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="11 92 42 255"
 		Accent.Selected="34 107 62 255" 
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="232 46 213 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/magenta.styles
+++ b/resource/styles/colors/magenta.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="153 0 94 255"
 		Accent.Selected="191 0 117 255"
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="0 255 255 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/orange.styles
+++ b/resource/styles/colors/orange.styles
@@ -5,7 +5,8 @@
 		Accent="255 185 0 255"
 		Accent.Hover="186 137 0 255"
 		Accent.Selected="192 148 25 255" 
-		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Accent.Text="0 0 0 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="0 43 178 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/purple.styles
+++ b/resource/styles/colors/purple.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="98 17 110 255"
 		Accent.Selected="113 40 124 255"
 		Accent.Text="225 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="255 185 0 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/red.styles
+++ b/resource/styles/colors/red.styles
@@ -6,6 +6,7 @@
 		Accent.Hover="153 0 13 255"
 		Accent.Selected="163 25 36 255"
 		Accent.Text="255 255 255 255" //Color of text on Accent color, usually white or black
+		Frame.Focus.Text=Accent.Text
 
 		AccentInv="20 173 208 255" //Complimentary color for disk usage
 		

--- a/resource/styles/colors/titlebar_black.styles
+++ b/resource/styles/colors/titlebar_black.styles
@@ -5,5 +5,6 @@
 		TitleBar="8 8 8 255"
 		TitleBar.Focus="8 8 8 255" //For loss of focus
 		Notification.Back="31 31 31 255" //fun fact: on windows 10 this is slightly transparent, so the actual color varies!
+		Frame.Focus.Text="255 255 255 255" // Ensures that TitleBar text is white
 	}
 }

--- a/resource/styles/steam.styles
+++ b/resource/styles/steam.styles
@@ -132,7 +132,7 @@ steam.styles
 	TitleBar.CloseButton="232 17 35 255" //Special colors for close X
 	TitleBar.CloseButton.Active="241 112 122 255"
 	Frame.Text="96 96 96 255"
-	Frame.Focus.Text=DefaultText
+	//Frame.Focus.Text=DefaultText // Now also defined in accent specific ini
 	
 	Root.Header = DefaultBackground
 	Root.TabBar = Light


### PR DESCRIPTION
This is needed, because in Windows 10, certain colors (orange) have their titlebar text in black. While the way this has been implemented seems convoluted, it's necessary since it needs to be changed to white if the titlebar is set to black. The only issue now is that symbols (e.g. "Minimize", "Maximize",...) still stay white.
This PR also fixes the Accent.Text value in orange.styles to be black.