### PR TITLE
Updates for latest Steam Client

### DIFF
--- a/resource/layout/overlaydesktop.layout
+++ b/resource/layout/overlaydesktop.layout
@@ -15,6 +15,7 @@
 		WebSiteButton { controlname="URLLabel" labeltext="#Overlay_Taskbar_WebSite" style=sidemenu }	
 		RecommendButton { controlname="URLLabel" labeltext="#Overlay_Taskbar_Recommend" style=sidemenu }	
 		WorkshopButton { controlname="URLLabel" labeltext="#Overlay_Taskbar_Workshop" style=sidemenu }	
+		EditControllerConfig { controlname="URLLabel" labeltext="#Overlay_Taskbar_EditControllerConfig" style=sidemenu }
 		ForceQuitButton { controlname="URLLabel" labeltext="#Overlay_Taskbar_ForceQuit" style=sidemenu }	
 		
 		FriendsDetailPanel { controlname="COverlay_Details_Friends" style="detailsbox" }
@@ -79,7 +80,7 @@
 		region	 { name="right" width=450 height=max align=right }
 		
 		region	 { name="gameOps" region=footer width=200 height=max align=right overflow=scroll-vertical}
-		place { control="LegacyCDKeyButton,GameGroupsButton,ChatRoomButton,DLCButton,GuideButton,WebSiteButton,RecommendButton,WorkshopButton,ForceQuitButton" align=right region=gameOps dir=down margin-right=20 margin-top=10}
+		place { control="LegacyCDKeyButton,GameGroupsButton,ChatRoomButton,DLCButton,GuideButton,WebSiteButton,RecommendButton,WorkshopButton,EditControllerConfig,ForceQuitButton" align=right region=gameOps dir=down margin-right=20 margin-top=10}
 		
 		place { control="BroadcastDetailPanel" region=right width=330 height=240 align=bottom }
 		

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -102,11 +102,11 @@
 		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=78 }
 
 		place { controls="ThrottleCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 x=270 margin-left=20 }
-		place { controls="ThrottleRateCurrent" region=box start=ThrottleCheckbox dir=down width=235 height=25 margin-top=4 }
-		place { controls="ThrottleRateEditLabel" region=box start=ThrottleRateCurrent dir=down width=175 height=25 }
+		place { controls="ThrottleRateCurrent" region=box start=ThrottleCheckbox dir=right width=235 height=25 margin-top=1 }
+		place { controls="ThrottleRateEditLabel" region=box start=ThrottleCheckbox dir=down width=175 height=25 }
 		place { controls="ThrottleRateEdit" region=box start=ThrottleRateEditLabel dir=down width=125 height=25 }
 		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=5 }
-		place { controls="ThrottleRateApply" region=box start=ThrottleRateEdit dir=down width=70 height=25 margin-top=4 }
+		place { controls="ThrottleRateApply" region=box start=ThrottleRateEdit dir=down width=70 height=25 margin-top=10 }
 
 		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=15 }
 		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down }

--- a/resource/layout/subpaneloptionsdownloads.layout
+++ b/resource/layout/subpaneloptionsdownloads.layout
@@ -2,7 +2,6 @@
 {
 	controls
 	{
-		ThrottleRatesLabel { controlname=label	labeltext=#Steam_ThrottleRatesLabel	}
 		RegionLabel {	controlname=label	labeltext=#Steam_RegionLabel	style=highlight 	}
 		LibrariesLabel {	controlname=label	labeltext=#Steam_LibrariesLabel	style=highlight }
 		RestrictionsLabel {	controlname=label	labeltext=#Steam_DownloadRestrictionsLabel	style=highlight 	}
@@ -10,11 +9,17 @@
 		ManageInstalledappsLabel { controlname=label labeltext=#SteamUI_ContentMgr_ManageInstalledAppsInfo }
 		FlushDownloadConfigLabel { controlname=label labeltext=#SteamUI_ContentMgr_FlushDownloadConfigInfo tooltiptext=#SteamUI_ContentMgr_FlushDownloadConfigTip }
 				
-		ThrottleRates
-		{
-			controlname=combobox
-			editable="0"
-		}	
+		ThrottleCheckbox { controlname=checkbutton  labeltext=#Steam_ThrottleRatesLabel }
+		ThrottleRateCurrent { controlname=label }
+		ThrottleRateEditLabel { controlname=label labeltext=#SteamUI_ThrottleEditLabel }
+		ThrottleRateEdit { controlname=textentry }
+		ThrottleRateEditSuffix { controlname=label }
+		ThrottleRateApply 
+		{ 
+			controlname=button 
+			labeltext = #SteamUI_ThrottleApplyChange
+			command=ChangeThrottleValue
+		}
 		
 		DownloadRegionCombo
 		{
@@ -96,8 +101,12 @@
 		place { controls="AutoUpdateTimeRestrictEndLabel" region=box start=AutoUpdateTimeRestrictStart dir=right margin-left=20 }
 		place { controls="AutoUpdateTimeRestrictEnd" region=box start=AutoUpdateTimeRestrictEndLabel dir=right margin-left=10 width=78 }
 
-		place { controls="ThrottleRatesLabel" region=box start=RestrictionsLabel dir=down margin-left=260 margin-top=6 }
-		place { controls="ThrottleRates" region=box start=ThrottleRatesLabel dir=down width=235 height=25 margin-top=10 }
+		place { controls="ThrottleCheckbox" region=box start=RestrictionsLabel dir=down margin-top=4 x=270 margin-left=20 }
+		place { controls="ThrottleRateCurrent" region=box start=ThrottleCheckbox dir=down width=235 height=25 margin-top=4 }
+		place { controls="ThrottleRateEditLabel" region=box start=ThrottleRateCurrent dir=down width=175 height=25 }
+		place { controls="ThrottleRateEdit" region=box start=ThrottleRateEditLabel dir=down width=125 height=25 }
+		place { controls="ThrottleRateEditSuffix" region=box start=ThrottleRateEdit dir=right margin-left=4 margin-top=5 }
+		place { controls="ThrottleRateApply" region=box start=ThrottleRateEdit dir=down width=70 height=25 margin-top=4 }
 
 		place { controls="AllowDownloadsDuringGameplayCheckbox" region=box start=AutoUpdateTimeRestrictStartLabel dir=down margin-top=15 }
 		place { controls="ThrottleDownloadsWhileStreamingCheckbox" region=box start=AllowDownloadsDuringGameplayCheckbox dir=down }

--- a/resource/layout/subpaneloptionsingame.layout
+++ b/resource/layout/subpaneloptionsingame.layout
@@ -28,8 +28,13 @@
 		PingRateCombo
 		{
 			controlname=combobox
-      			editable="0"
-		}		
+      		editable="0"
+		}
+
+		TextFilterLabel { controlname=label labeltext="#Steam_TextFilterSettingLabel"	wrap=1	style=highlight }
+		TextFilterStatus { controlname=label	wrap=1		}
+		TextFilterUpdateSettingURL { controlname=URLLabel	labeltext=#Steam_TextFilterSettingURL	URLText="steam://url/TextFilterSettings" }
+	
 	}
 	
 	colors
@@ -84,8 +89,12 @@
 			margin-top=6 margin-left=10 region=box }
 		
 		place { control=Divider1 start=ShowIngameFPSContrastCheck dir=down margin-top=40 region=box width=max }
-		place { controls="PingRateLabel" region=box start=Divider1 margin-top=10 width=max dir=down }
+		place { controls="PingRateLabel" region=box start=Divider1 margin-top=10 width=250 dir=down }
 		place { controls="PingRateCombo" region=box start=PingRateLabel margin-top=10 width=235 dir=down height=25 }
-		place { controls="PingRateInfo" region=box start=PingRateCombo margin-top=10 width=max dir=down }				
+		place { controls="PingRateInfo" region=box start=PingRateCombo margin-top=10 width=250 dir=down }		
+
+		place { control=TextFilterLabel start=Divider1 margin-top=10 x=270 width=300 dir=down }
+		place { control=TextFilterStatus start=TextFilterLabel margin-top=10 width=300 dir=down }
+		place { control=TextFilterUpdateSettingURL start=TextFilterStatus margin-top=10 width=300 dir=down height=25 }
 	}
 }

--- a/resource/layout/subpaneloptionsingame.layout
+++ b/resource/layout/subpaneloptionsingame.layout
@@ -33,7 +33,7 @@
 
 		TextFilterLabel { controlname=label labeltext="#Steam_TextFilterSettingLabel"	wrap=1	style=highlight }
 		TextFilterStatus { controlname=label	wrap=1		}
-		TextFilterUpdateSettingURL { controlname=URLLabel	labeltext=#Steam_TextFilterSettingURL	URLText="steam://url/TextFilterSettings" }
+		TextFilterUpdateSettingURL { controlname=URLLabel	labeltext=#Steam_TextFilterSettingURL	URLText="steam://url/TextFilterSettings"	wrap=1 }
 	
 	}
 	
@@ -89,12 +89,13 @@
 			margin-top=6 margin-left=10 region=box }
 		
 		place { control=Divider1 start=ShowIngameFPSContrastCheck dir=down margin-top=40 region=box width=max }
-		place { controls="PingRateLabel" region=box start=Divider1 margin-top=10 width=250 dir=down }
-		place { controls="PingRateCombo" region=box start=PingRateLabel margin-top=10 width=235 dir=down height=25 }
+		
+		place { control=TextFilterLabel start=Divider1 margin-top=10 width=250 dir=down }
+		place { control=TextFilterStatus start=TextFilterLabel margin-top=10 width=250 dir=down }
+		place { control=TextFilterUpdateSettingURL start=TextFilterStatus margin-top=10 width=250 dir=down height=25 }
+		
+		place { controls="PingRateLabel" region=box start=Divider1 margin-top=10 x=270 width=max dir=down }
+		place { controls="PingRateCombo" region=box start=PingRateLabel margin-top=10 width=220 dir=down height=25 }
 		place { controls="PingRateInfo" region=box start=PingRateCombo margin-top=10 width=250 dir=down }		
-
-		place { control=TextFilterLabel start=Divider1 margin-top=10 x=270 width=300 dir=down }
-		place { control=TextFilterStatus start=TextFilterLabel margin-top=10 width=300 dir=down }
-		place { control=TextFilterUpdateSettingURL start=TextFilterStatus margin-top=10 width=300 dir=down height=25 }
 	}
 }


### PR DESCRIPTION
Hi, I'm back
- Fixed misplaced controller configuration setting in In-game Overlay 
- Fixed custom limit bandwidth in Downloads settings (also made the currently set throttle sit next to the "Current Limit" label)
- Fixed chat filtering in In-Game settings

**Issues**
I could not for the life of me or the software adjust the "Change Chat Filtering Preferences" URL label style in the In-Game settings. Any attempts to force a new style did not work for me but I'm fairly new at this, so if you know of a fix I'll be more than glad to accept any changes.